### PR TITLE
cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 
 # rspec failure tracking
 .rspec_status
+coverage

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,11 +2,15 @@ AllCops:
   TargetRubyVersion: 2.4
   DisplayCopNames: true
 
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+Layout/LeadingCommentSpace:
+  Enabled: false
+Layout/RescueEnsureAlignment:
+  Enabled: false
 Lint/RescueException:
   Enabled: false
-
 Metrics:
   Enabled: false
-
 Style:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ before_install:
   - sudo apt-get install -y socat pv
   - gem install bundler
 rvm:
-  - 2.3.5
-  - 2.4.2
-  - jruby-9.1.13.0
+  - 2.4.5
+  - 2.5.3
+  - 2.6.1
+  - jruby-9.1.17.0
+  - jruby-9.2.5.0
   - ruby-head
 matrix:
   allow_failures:

--- a/Gemfile
+++ b/Gemfile
@@ -3,14 +3,15 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in zk_recipes.gemspec
 gemspec
 
-gem "bundler", "~> 1.14"
 gem "descriptive_statistics", "~> 2.5"
 gem "pry"
-gem "rake", "~> 10.0"
-gem "rspec", "~> 3.6"
-gem "rubocop", "0.49.1"
+gem "rake"
+gem "rspec", "~> 3.8"
+gem "rubocop", "0.63.1"
+gem 'simplecov'
 gem "zk-server", "~> 1.1"
 
 platform :mri do
+  gem "concurrent-ruby-ext"
   gem "pry-byebug"
 end

--- a/lib/zk_recipes/cache.rb
+++ b/lib/zk_recipes/cache.rb
@@ -6,6 +6,7 @@ module ZkRecipes
     class PathError < Error; end
 
     AS_NOTIFICATION = "cache.zk_recipes"
+    USE_DEFAULT = Object.new
 
     def initialize(logger: nil, host: nil, timeout: nil, zk_opts: {})
       @cache = Concurrent::Map.new
@@ -37,15 +38,15 @@ module ZkRecipes
     def register(path, default_value, &block)
       raise Error, "register only allowed before setup_callbacks called" unless @registerable
 
-      debug { "added path=#{path} default_value=#{default_value.inspect}" }
       @cache[path] = CachedPath.new(default_value)
       @registered_values[path] = RegisteredPath.new(default_value, block)
+      @logger&.debug { "added path=#{path} default_value=#{default_value.inspect}" }
       ActiveSupport::Notifications.instrument(AS_NOTIFICATION, path: path, value: default_value)
     end
 
-    def setup_callbacks(zk)
+    def setup_callbacks(zk_client)
       raise Error, "setup_callbacks can only be called once" unless @registerable
-      @zk = zk
+      @zk = zk_client
       @registerable = false
 
       if @zk.connected? || @zk.connecting?
@@ -55,24 +56,25 @@ module ZkRecipes
       @registered_values.each do |path, _value|
         @watches[path] = @zk.register(path) do |event|
           if event.node_event?
-            debug { "node event path=#{event.path} #{event.event_name} #{event.state_name}" }
+            @logger&.debug { "node event path=#{event.path} #{event.event_name} #{event.state_name}" }
             unless update_cache(event.path)
               @pending_updates[path] = nil
               @zk.defer { process_pending_updates }
             end
           else
-            warn { "session event #{event.event_name} #{event.state_name}" }
+            @logger&.warn { "session event #{event.event_name} #{event.state_name}" }
           end
         end
       end
 
       @watches["on_connected"] = @zk.on_connected do
         if @session_id == @zk.session_id
+          @logger&.debug("on_connected: reconnected existing session")
           process_pending_updates
           next
         end
 
-        debug("on_connected new session")
+        @logger&.debug("on_connected: new session")
         @pending_updates.clear
         @registered_values.each do |path, _value|
           @pending_updates[path] = nil unless update_cache(path)
@@ -82,16 +84,16 @@ module ZkRecipes
       end
 
       @zk.on_exception do |e|
-        error { "on_exception exception=#{e.inspect} backtrace=#{e.backtrace.inspect}" }
+        @logger&.error { "on_exception: exception=#{e.inspect} backtrace=#{e.backtrace.inspect}" }
       end
     end
 
     def wait_for_warm_cache(timeout = 30)
-      debug { "waiting for cache to warm timeout=#{timeout.inspect}" }
+      @logger&.debug { "waiting for cache to warm timeout=#{timeout.inspect}" }
       if @latch.wait(timeout)
         true
       else
-        warn { "didn't warm cache before timeout connected=#{@zk.connected?} timeout=#{timeout.inspect}" }
+        @logger&.warn { "didn't warm cache before timeout connected=#{@zk.connected?} timeout=#{timeout.inspect}" }
         false
       end
     end
@@ -135,7 +137,7 @@ module ZkRecipes
     def connect(host, zk_opts)
       raise Error, "already connected" if @zk
 
-      debug { "connecting host=#{host.inspect}" }
+      @logger&.debug { "connecting host=#{host.inspect}" }
       ZK.new(host, **zk_opts) do |zk|
         setup_callbacks(zk)
       end
@@ -150,7 +152,7 @@ module ZkRecipes
       unless stat.exists?
         value = @registered_values.fetch(path).default_value
         @cache[path] = CachedPath.new(value, stat: stat)
-        debug { "no node, setting watch path=#{path}" }
+        @logger&.debug { "update_cache: no data node, setting watch path=#{path}" }
         instrument_params[:value] = value
         ActiveSupport::Notifications.instrument(AS_NOTIFICATION, instrument_params)
         return true
@@ -167,7 +169,7 @@ module ZkRecipes
         registered_value = @registered_values.fetch(path)
         instrument_params[:value] = registered_value.deserialize(raw_value)
       rescue => e
-        error { "deserialization error path=#{path} stat=#{stat.inspect} exception=#{e.inspect} #{e.backtrace.inspect}" }
+        @logger&.error { "deserialization error path=#{path} stat=#{stat.inspect} exception=#{e.inspect} #{e.backtrace.inspect}" }
         instrument_params[:error] = e
         instrument_params[:raw_value] = raw_value
         valid = false
@@ -182,34 +184,32 @@ module ZkRecipes
       @cache[path] = CachedPath.new(value, stat: stat, valid: valid)
 
       ActiveSupport::Notifications.instrument(AS_NOTIFICATION, instrument_params)
-      debug { "update_cache path=#{path} raw_value=#{raw_value.inspect} value=#{value.inspect} stat=#{stat.inspect}" }
+      @logger&.debug { "update_cache: path=#{path} raw_value=#{raw_value.inspect} value=#{value.inspect} stat=#{stat.inspect}" }
       true
     rescue ::ZK::Exceptions::ZKError => e
-      warn { "update_cache path=#{path} exception=#{e.inspect}, retrying" }
+      @logger&.warn { "update_cache: path=#{path} exception=#{e.inspect}, retrying" }
       retry
     rescue ::ZK::Exceptions::KeeperException, ::Zookeeper::Exceptions::ZookeeperException => e
-      error { "update_cache path=#{path} exception=#{e.inspect}" }
+      @logger&.error { "update_cache: path=#{path} exception=#{e.inspect}" }
       false
     end
 
     def process_pending_updates
-      return if @pending_updates.empty?
-      debug { "processing pending updates=#{@pending_updates.size}" }
+      if @pending_updates.empty?
+        @logger&.debug("process_pending_updates: no pending updates")
+        return
+      end
+
+      unless @zk.connected?
+        @logger&.debug("process_pending_updates: zk not connected")
+        return
+      end
+
+      @logger&.debug { "processing pending updates=#{@pending_updates.size}" }
       @pending_updates.reject! do |missed_path, _|
         update_cache(missed_path)
       end
     end
-
-    %w(debug warn error).each do |m|
-      module_eval <<~EOM, __FILE__, __LINE__
-        def #{m}(msg = nil)
-          return unless @logger
-          @logger.#{m} { msg || yield }
-        end
-      EOM
-    end
-
-    USE_DEFAULT = Object.new
 
     class CachedPath
       attr_reader :value, :stat
@@ -223,11 +223,13 @@ module ZkRecipes
         @valid
       end
     end
+    private_constant :CachedPath
 
     class RegisteredPath < Struct.new(:default_value, :deserializer)
       def deserialize(raw)
         deserializer ? deserializer.call(raw) : raw
       end
     end
+    private_constant :RegisteredPath
   end
 end

--- a/spec/zk_recipes/cache_spec.rb
+++ b/spec/zk_recipes/cache_spec.rb
@@ -1,28 +1,31 @@
 # frozen_string_literal: true
 
 RSpec.describe ZkRecipes::Cache, zookeeper: true do
-  let(:logger) { Logger.new(STDERR).tap { |l| l.level = ENV["ZK_RECIPES_DEBUG"] ? Logger::DEBUG : Logger::WARN } }
-  let(:host) { "localhost:#{ZK_PORT}" }
+  let(:logger) do
+    TestLogger.new((ENV["ZK_RECIPES_DEBUG"].present? ? STDERR : nil), formatter: Formatter.new)
+  end
+  let(:closers) { [] }
+  let(:host) { |example| "localhost:#{example.metadata[:proxy] ? PROXY_PORT : ZK_PORT}" }
   let(:cache) do
     ZkRecipes::Cache.new(host: host, logger: logger, timeout: 10, zk_opts: { timeout: 5 }) do |z|
       z.register("/test/boom", "goat")
       z.register("/test/foo", 1) { |raw_value| raw_value.to_i * 2 }
+      closers << z
     end
   end
 
   let(:zk) do
     ZK.new("localhost:#{ZK_PORT}").tap do |z|
-      z.on_exception { |e| zk_exceptions << e.class }
+      z.on_exception { |e| logger.error { "on_exception: exception=#{e.inspect} backtrace=#{e.backtrace.inspect}" } }
+      closers << z
     end
   end
-  let(:zk_exceptions) { Set.new }
   let(:zk_cache_exceptions) { Set.new }
 
   after do
-    zk.close!
-    cache.close!
-    expect(zk_exceptions.empty?).to be(true)
-    expect(zk_cache_exceptions.empty?).to be(true)
+    closers.each(&:close!)
+    expect(TestLogger.errors).to eq([])
+    TestLogger.errors.clear
   end
 
   describe ".new" do
@@ -35,9 +38,24 @@ RSpec.describe ZkRecipes::Cache, zookeeper: true do
     it "sets up callbacks, waits for the cache to warm, but does not connect to ZK without a block" do
       z = ZK.new(host, connect: false)
       cache = ZkRecipes::Cache.new
+      closers << cache
       cache.setup_callbacks(z)
       expect(Benchmark.realtime { cache.wait_for_warm_cache(5) } >= 5).to be(true)
       expect(z.connected?).to be(false)
+    end
+  end
+
+  describe "#register" do
+    it "raises if called after initialization with a block" do
+      expect { cache.register("/test/blamo", "cat") }.to raise_error(described_class::Error)
+    end
+
+    it "raises if called after setup_callbacks" do
+      z = ZK.new(host, connect: false)
+      cache = ZkRecipes::Cache.new
+      closers << cache
+      cache.setup_callbacks(z)
+      expect { cache.register("/test/blamo", "cat") }.to raise_error(described_class::Error)
     end
   end
 
@@ -45,6 +63,9 @@ RSpec.describe ZkRecipes::Cache, zookeeper: true do
     it "fetches registered paths" do
       expect(cache["/test/boom"]).to eq("goat")
       expect(cache.fetch("/test/boom")).to eq("goat")
+      zk.create("/test/boom", "cat")
+      almost_there { expect(cache["/test/boom"]).to eq("cat") }
+      almost_there { expect(cache.fetch("/test/boom")).to eq("cat") }
     end
 
     it "raises a PathError for unregistered paths" do
@@ -54,8 +75,7 @@ RSpec.describe ZkRecipes::Cache, zookeeper: true do
 
   describe "#fetch_valid" do
     it "fetches registered paths that are set" do
-      zk.create("/test/boom")
-      zk.set("/test/boom", "cat")
+      zk.create("/test/boom", "cat")
       almost_there { expect(cache.fetch_valid("/test/boom")).to eq("cat") }
     end
 
@@ -66,15 +86,16 @@ RSpec.describe ZkRecipes::Cache, zookeeper: true do
     context "paths with deserialization errors" do
       let(:cache) do
         ZkRecipes::Cache.new(host: host, logger: logger, timeout: 10, zk_opts: { timeout: 5 }) do |z|
+          closers << z
           z.register("/test/boom", "goat") { |_| raise "never valid" }
         end
       end
 
       it "returns nil" do
         expect(cache.fetch_valid("/test/boom")).to be(nil)
-        zk.create("/test/boom")
-        zk.set("/test/boom", "cat")
+        zk.create("/test/boom", "cat")
         almost_there { expect(cache.fetch_valid("/test/boom")).to be(nil) }
+        expect_logged_errors(/never valid/)
       end
     end
 
@@ -86,7 +107,8 @@ RSpec.describe ZkRecipes::Cache, zookeeper: true do
   describe "USE_DEFAULT" do
     let(:cache) do
       ZkRecipes::Cache.new(host: host, logger: logger, timeout: 10, zk_opts: { timeout: 5 }) do |z|
-        z.register("/test/boom", "goat") { |_| return ::ZkRecipes::Cache::USE_DEFAULT }
+        closers << z
+        z.register("/test/boom", "goat") { |_| ::ZkRecipes::Cache::USE_DEFAULT }
       end
     end
 
@@ -99,172 +121,165 @@ RSpec.describe ZkRecipes::Cache, zookeeper: true do
     end
   end
 
-  it "works" do
-    expect(cache["/test/boom"]).to eq("goat")
-    expect(cache["/test/foo"]).to eq(1)
-
-    zk.create("/test/boom")
-    zk.set("/test/boom", "cat")
-    almost_there { expect(cache["/test/boom"]).to eq("cat") }
-
-    zk.create("/test/foo")
-    zk.set("/test/foo", "1")
-    almost_there { expect(cache["/test/foo"]).to eq(2) }
-  end
-
-  context "with an external ZK client" do
-    let(:zk_cache) { ZK.new(host, connect: false) }
-    after { zk_cache.close! }
-
-    let(:cache) do
-      cache = ZkRecipes::Cache.new(logger: logger)
-      cache.register("/test/boom", "goat")
-      cache.register("/test/foo", 1) { |raw_value| raw_value.to_i * 2 }
-      cache.setup_callbacks(zk_cache)
-      zk_cache.connect
-      cache
-    end
-
-    it "works" do
+  describe "acceptance test", slow: true do
+    def check_everything
       expect(cache["/test/boom"]).to eq("goat")
       expect(cache["/test/foo"]).to eq(1)
 
-      zk.create("/test/boom")
-      zk.set("/test/boom", "cat")
+      zk.create("/test/boom", "cat")
       almost_there { expect(cache["/test/boom"]).to eq("cat") }
 
-      zk.create("/test/foo")
-      zk.set("/test/foo", "1")
+      zk.create("/test/foo", "1")
       almost_there { expect(cache["/test/foo"]).to eq(2) }
     end
-  end
 
-  describe "flakey connections", proxy: true do
-    let(:host) { "localhost:#{PROXY_PORT}" }
+    it "works" do
+      check_everything
+    end
 
-    context "with slow connections", throttle_bytes_per_sec: 100 do
+    context "with an external ZK client" do
+      let(:zk_cache) { ZK.new(host, connect: false).tap { |z| closers << z } }
+
+      let(:cache) do
+        cache = ZkRecipes::Cache.new(logger: logger)
+        closers << cache
+        cache.register("/test/boom", "goat")
+        cache.register("/test/foo", 1) { |raw_value| raw_value.to_i * 2 }
+        cache.setup_callbacks(zk_cache)
+        zk_cache.connect
+        cache
+      end
+
       it "works" do
-        expect(cache["/test/boom"]).to eq("goat")
-        expect(cache["/test/foo"]).to eq(1)
+        check_everything
+      end
+    end
 
-        zk.create("/test/boom")
-        zk.set("/test/boom", "cat")
+    describe "flakey connections", proxy: true do
+      context "with slow connections", throttle_bytes_per_sec: 100 do
+        it "works" do
+          check_everything
+        end
+      end
+
+      it "works with dropped connections" do
+        expect(cache["/test/boom"]).to eq("goat")
+        zk.create("/test/boom", "cat")
         almost_there { expect(cache["/test/boom"]).to eq("cat") }
 
-        zk.create("/test/foo")
-        zk.set("/test/foo", "1")
-        almost_there { expect(cache["/test/foo"]).to eq(2) }
+        proxy_stop
+        sleep 1
+
+        zk.set("/test/boom", "dog")
+        expect(cache["/test/boom"]).to eq("cat")
+
+        sleep 12
+        proxy_start
+        sleep 1
+
+        almost_there { expect(cache["/test/boom"]).to eq("dog") }
       end
     end
 
-    it "works with dropped connections" do
-      expect(cache["/test/boom"]).to eq("goat")
-      zk.create("/test/boom")
-      zk.set("/test/boom", "cat")
-      almost_there { expect(cache["/test/boom"]).to eq("cat") }
-      proxy_stop
-      sleep 1
-      zk.set("/test/boom", "dog")
-      expect(cache["/test/boom"]).to eq("cat")
-      sleep 12
-      proxy_start
-      sleep 1
-      almost_there { expect(cache["/test/boom"]).to eq("dog") }
-    end
-  end
-
-  if Process.respond_to?(:fork)
-    describe "reopen after fork", proxy: true, throttle_bytes_per_sec: 50 do
-      let(:host) { "localhost:#{PROXY_PORT}" }
-
-      context "with external ZK client" do
-        let!(:cache) do
-          cache = ZkRecipes::Cache.new(logger: logger)
-          cache.register("/test/boom", "goat")
-          cache.setup_callbacks(zk_cache)
-          zk_cache.connect
-          cache.wait_for_warm_cache(5)
-          cache
-        end
-
-        let(:zk_cache) do
-          ZK.new(host, connect: false, timeout: 5).tap do |z|
-            z.on_exception { |e| zk_cache_exceptions << e.class }
+    if Process.respond_to?(:fork)
+      describe "reopen after fork", proxy: true, throttle_bytes_per_sec: 50 do
+        context "with external ZK client" do
+          let!(:cache) do
+            cache = ZkRecipes::Cache.new(logger: logger)
+            closers << cache
+            cache.register("/test/boom", "goat")
+            cache.register("/test/foo", 1) { |raw_value| raw_value.to_i * 2 }
+            cache.setup_callbacks(zk_cache)
+            zk_cache.connect
+            cache.wait_for_warm_cache(5)
+            cache
           end
-        end
-        after { zk_cache.close! }
 
-        it "works" do
-          child_pid = fork
-          if child_pid
-            # parent
-            begin
-              zk.create("/test/boom")
-              zk.set("/test/boom", "cat")
-              almost_there { expect(cache["/test/boom"]).to eq("cat") }
-
-              _, status = Process.wait2(child_pid)
-              expect(status.exitstatus).to eq(0) # exitstatus == 0 => tests passed in child
-            rescue
-              Process.wait(child_pid) rescue nil
-              raise
+          let(:zk_cache) do
+            ZK.new(host, connect: false, timeout: 5).tap do |z|
+              z.on_exception { |e| logger.error { "on_exception: exception=#{e.inspect} backtrace=#{e.backtrace.inspect}" } }
+              closers << z
             end
-            raise "zk_cache_exceptions=#{zk_cache_exceptions.inspect}" unless zk_cache_exceptions.empty?
-            raise "zk_exceptions=#{zk_exceptions.inspect}" unless zk_exceptions.empty?
-          else
-            # child
-            begin
-              cache.reopen
-              zk_cache.reopen
-              expect(cache.wait_for_warm_cache(1)).to be(false)
-              expect(cache.wait_for_warm_cache(5)).to be(true)
-              expect(cache["/test/boom"]).to eq("cat")
-              raise "zk_cache_exceptions=#{zk_cache_exceptions.inspect}" unless zk_cache_exceptions.empty?
-              raise "zk_exceptions=#{zk_exceptions.inspect}" unless zk_exceptions.empty?
-              exit!(0)
-            rescue Exception => e
-              puts "child failed #{e}\n#{e.backtrace.join("\n")}"
-              exit!(1)
+          end
+
+          it "works" do
+            child_pid = fork
+            if child_pid
+              # parent
+              begin
+                check_everything
+
+                _, status = Process.wait2(child_pid)
+                expect(status.exitstatus).to eq(0) # exitstatus == 0 => tests passed in child
+              rescue
+                Process.wait(child_pid) rescue nil
+                raise
+              end
+              raise "zk_cache_exceptions=#{TestLogger.errors.inspect}" unless TestLogger.errors.empty?
+            else
+              # child
+              begin
+                if ENV["COVERAGE"]
+                  SimpleCov.command_name SecureRandom.uuid
+                  SimpleCov.start
+                end
+
+                cache.reopen
+                zk_cache.reopen
+                expect(cache.wait_for_warm_cache(1)).to be(false)
+                expect(cache.wait_for_warm_cache(10)).to be(true)
+                almost_there { expect(cache["/test/boom"]).to eq("cat") }
+                almost_there { expect(cache["/test/foo"]).to eq(2) }
+                expect_logged_errors(/didn't warm cache before timeout connected=true timeout=1/)
+                exit!(0)
+              rescue Exception => e
+                puts "child failed #{e}\n#{e.backtrace.join("\n")}"
+                exit!(1)
+              end
             end
           end
         end
-      end
 
-      context "with internal ZK client (cache creates it's ZK client)" do
-        let!(:cache) do
-          ZkRecipes::Cache.new(host: host, logger: logger, timeout: 10, zk_opts: { timeout: 5 }) do |z|
-            z.register("/test/boom", "goat")
-          end
-        end
-
-        it "works" do
-          child_pid = fork
-          if child_pid
-            # parent
-            begin
-              zk.create("/test/boom")
-              zk.set("/test/boom", "cat")
-              almost_there { expect(cache["/test/boom"]).to eq("cat") }
-
-              _, status = Process.wait2(child_pid)
-              expect(status.exitstatus).to eq(0) # exitstatus == 0 => tests passed in child
-            rescue
-              Process.wait(child_pid) rescue nil
-              raise
+        context "with internal ZK client (cache creates it's ZK client)" do
+          let!(:cache) do
+            ZkRecipes::Cache.new(host: host, logger: logger, timeout: 10, zk_opts: { timeout: 5 }) do |z|
+              closers << z
+              z.register("/test/boom", "goat")
+              z.register("/test/foo", 1) { |raw_value| raw_value.to_i * 2 }
             end
-            raise "zk_cache_exceptions=#{zk_cache_exceptions.inspect}" unless zk_cache_exceptions.empty?
-            raise "zk_exceptions=#{zk_exceptions.inspect}" unless zk_exceptions.empty?
-          else
-            # child
-            begin
-              cache.reopen
-              expect(cache["/test/boom"]).to eq("cat")
-              raise "zk_cache_exceptions=#{zk_cache_exceptions.inspect}" unless zk_cache_exceptions.empty?
-              raise "zk_exceptions=#{zk_exceptions.inspect}" unless zk_exceptions.empty?
-              exit!(0)
-            rescue Exception => e
-              puts "child failed #{e}\n#{e.backtrace.join("\n")}"
-              exit!(1)
+          end
+
+          it "works" do
+            child_pid = fork
+            if child_pid
+              # parent
+              begin
+                check_everything
+
+                _, status = Process.wait2(child_pid)
+                expect(status.exitstatus).to eq(0) # exitstatus == 0 => tests passed in child
+              rescue
+                Process.wait(child_pid) rescue nil
+                raise
+              end
+              raise "zk_cache_exceptions=#{TestLogger.errors.inspect}" unless TestLogger.errors.empty?
+            else
+              # child
+              begin
+                if ENV["COVERAGE"]
+                  SimpleCov.command_name SecureRandom.uuid
+                  SimpleCov.start
+                end
+
+                cache.reopen
+                almost_there { expect(cache["/test/boom"]).to eq("cat") }
+                almost_there { expect(cache["/test/foo"]).to eq(2) }
+                raise "zk_cache_exceptions=#{TestLogger.errors.inspect}" unless TestLogger.errors.empty?
+                exit!(0)
+              rescue Exception => e
+                puts "child failed #{e}\n#{e.backtrace.join("\n")}"
+                exit!(1)
+              end
             end
           end
         end

--- a/zk_recipes.gemspec
+++ b/zk_recipes.gemspec
@@ -21,6 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  unless RUBY_ENGINE == "jruby"
+    spec.required_ruby_version = '>= 2.4'
+  end
+
   spec.add_runtime_dependency "activesupport", ">= 4.0"
   spec.add_runtime_dependency "concurrent-ruby", "~> 1.0"
   spec.add_runtime_dependency "zk", "~> 1.9"


### PR DESCRIPTION
- make constants private
- re-introduce explicit @logger (drops support for ruby < 2.3)
- cleanup tests, refactor acceptance tests
- upgrade dev dependencies, fix rubocop lints
- add simplecov